### PR TITLE
Add missing step to build instructions for AltServer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ AltStore and AltServer are both fairly straightforward to compile and run if you
 3. Open `AltStore.xcworkspace` and select the AltStore project in the project navigator. On the `Signing & Capabilities` tab, change the team from `Yvette Testut` to your own account.
 4. **(AltStore only)** Change the value for `ALTDeviceID` in the Info.plist to your device's UDID. Normally, AltServer embeds the device's UDID in AltStore's Info.plist during installation. When running through Xcode you'll need to set the value yourself or else AltStore won't resign (or even install) apps for the proper device.
 5. **(AltStore only)** Change the value for `ALTServerID` in the Info.plist to your AltServer's serverID. This is embedded by AltServer during installation to help AltStore distinguish between multiple AltServers on the same network, and you can find this by using a Bonjour browsing application and noting the serverID advertised by AltServer. This isn't strictly necessary, because if AltStore can't find the AltServer with the embedded serverID it still falls back to trying another AltServer. However, this will help in cases where there are multiple AltServers running (plus the error messages are more helpful).
-6. Build + run app! 🎉
+6. **(AltServer only)** Install Carthage (if you use Homebrew, you can do this with `brew install carthage`). Then run `carthage update` in the root directory of the repository.
+7. Build + run app! 🎉
 
 ## Licensing
 


### PR DESCRIPTION
You need to run `carthage update` to build AltServer.
Adding that information to the README.