### PR TITLE
Prioritise Paid Developer Team over Free Team

### DIFF
--- a/AltStore/Operations/AuthenticationOperation.swift
+++ b/AltStore/Operations/AuthenticationOperation.swift
@@ -413,11 +413,11 @@ private extension AuthenticationOperation
     {
         func selectTeam(from teams: [ALTTeam])
         {
-            if let team = teams.first(where: { $0.type == .free })
+            if let team = teams.first(where: { $0.type == .individual })
             {
                 return completionHandler(.success(team))
             }
-            else if let team = teams.first(where: { $0.type == .individual })
+            else if let team = teams.first(where: { $0.type == .free })
             {
                 return completionHandler(.success(team))
             }


### PR DESCRIPTION
If an account has both a free and paid developer team active concurrently (like mine), then the free team is selected first. Maybe prefer the paid team for a longer signing period instead?