### PR TITLE
Preserve device specific keys in Info.plist

### DIFF
--- a/AltKit/Bundle+AltStore.swift
+++ b/AltKit/Bundle+AltStore.swift
@@ -38,4 +38,9 @@ public extension Bundle
         let infoPlistURL = self.bundleURL.appendingPathComponent("ALTCertificate.p12")
         return infoPlistURL
     }
+    
+    var completeInfoDictionary: [String : Any]? {
+        let infoPlistURL = self.infoPlistURL
+        return NSDictionary(contentsOf: infoPlistURL) as? [String : Any]
+    }
 }

--- a/AltStore/Model/DatabaseManager.swift
+++ b/AltStore/Model/DatabaseManager.swift
@@ -181,7 +181,7 @@ private extension DatabaseManager
                         
                         let infoPlistURL = temporaryFileURL.appendingPathComponent("Info.plist")
                         
-                        guard var infoDictionary = Bundle.main.infoDictionary else { throw ALTError(.missingInfoPlist) }
+                        guard var infoDictionary = Bundle.main.completeInfoDictionary else { throw ALTError(.missingInfoPlist) }
                         infoDictionary[kCFBundleIdentifierKey as String] = StoreApp.altstoreAppID
                         try (infoDictionary as NSDictionary).write(to: infoPlistURL)
                         

--- a/AltStore/Operations/ResignAppOperation.swift
+++ b/AltStore/Operations/ResignAppOperation.swift
@@ -109,7 +109,7 @@ private extension ResignAppOperation
         {
             guard let identifier = bundle.bundleIdentifier else { throw ALTError(.missingAppBundle) }
             guard let profile = profiles[identifier] else { throw ALTError(.missingProvisioningProfile) }
-            guard var infoDictionary = bundle.infoDictionary else { throw ALTError(.missingInfoPlist) }
+            guard var infoDictionary = bundle.completeInfoDictionary else { throw ALTError(.missingInfoPlist) }
             
             infoDictionary[kCFBundleIdentifierKey as String] = profile.bundleIdentifier
             
@@ -147,7 +147,7 @@ private extension ResignAppOperation
                 progress.becomeCurrent(withPendingUnitCount: 1)
                 
                 guard let appBundle = Bundle(url: appBundleURL) else { throw ALTError(.missingAppBundle) }
-                guard let infoDictionary = appBundle.infoDictionary else { throw ALTError(.missingInfoPlist) }
+                guard let infoDictionary = appBundle.completeInfoDictionary else { throw ALTError(.missingInfoPlist) }
                 
                 var allURLSchemes = infoDictionary[Bundle.Info.urlTypes] as? [[String: Any]] ?? []
                 


### PR DESCRIPTION
Apple's Info.plist support platform and device specific keys to augment existing
keys. For example `UISupportedInterfaceOrientations~ipad` replaces
`UISupportedInterfaceOrientations` when running on an iPad.

By using Bundle.infoDictionary, Apple will pre-process the Info.plist and replace
any key with its device specific variant. Since AltStore does not support iPad,
this will strip out any iPad specific keys for the installing app.

We add an extension Bundle.completeInfoDictionary that will return the original
de-serialized dictionary including all the device specific keys.

See: https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html#//apple_ref/doc/uid/TP40009254-SW9

This resolves https://github.com/utmapp/UTM/issues/369