### PR TITLE
Make file providers work at all 

### DIFF
--- a/AltStore/Operations/ResignAppOperation.swift
+++ b/AltStore/Operations/ResignAppOperation.swift
@@ -126,7 +126,7 @@ private extension ResignAppOperation
                 // To keep file providers working, remap the NSExtensionFileProviderDocumentGroup, if there is one.
                 if var extensionInfo = infoDictionary["NSExtension"] as? [String: Any],
                     let appGroup = extensionInfo["NSExtensionFileProviderDocumentGroup"] as? String,
-                    let localAppGroup = appGroups.filter({ $0.starts(with: appGroup + ".") }).min(by: { $0.count < $1.count })
+                    let localAppGroup = appGroups.filter({ $0.contains(appGroup) }).min(by: { $0.count < $1.count })
                 {
                     extensionInfo["NSExtensionFileProviderDocumentGroup"] = localAppGroup
                     infoDictionary["NSExtension"] = extensionInfo


### PR DESCRIPTION
NSExtensionFileProviderDocumentGroup must be a valid app group. This
updates it to use the new name of the app group including the team ID.