### PR TITLE
Include `ALTDeviceID` on install of apps

### DIFF
--- a/AltServer/Devices/ALTDeviceManager+Installation.swift
+++ b/AltServer/Devices/ALTDeviceManager+Installation.swift
@@ -761,7 +761,10 @@ To prevent this from happening, feel free to try again with another Apple ID.
             
             infoDictionary[kCFBundleIdentifierKey as String] = profile.bundleIdentifier
             infoDictionary[Bundle.Info.altBundleID] = identifier
-            infoDictionary[Bundle.Info.deviceID] = device.identifier
+            
+            if (infoDictionary.keys.contains(Bundle.Info.deviceID)) {
+                infoDictionary[Bundle.Info.deviceID] = device.identifier
+            }
 
             for (key, value) in additionalInfoDictionaryValues
             {

--- a/AltServer/Devices/ALTDeviceManager+Installation.swift
+++ b/AltServer/Devices/ALTDeviceManager+Installation.swift
@@ -761,6 +761,7 @@ To prevent this from happening, feel free to try again with another Apple ID.
             
             infoDictionary[kCFBundleIdentifierKey as String] = profile.bundleIdentifier
             infoDictionary[Bundle.Info.altBundleID] = identifier
+            infoDictionary[Bundle.Info.deviceID] = device.identifier
 
             for (key, value) in additionalInfoDictionaryValues
             {


### PR DESCRIPTION
Fixes an issue that prevents AltKit from working as expected