### PR TITLE
Add up to macOS 12.1 UUIDs

### DIFF
--- a/AltPlugin/Info.plist
+++ b/AltPlugin/Info.plist
@@ -62,5 +62,50 @@
 	<array>
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 	</array>
+	<key>Supported11.10PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.1PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.2PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.3PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.4PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.5PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.6PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.7PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.8PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported12.0PluginCompatibilityUUIDs</key>
+	<array>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported12.1PluginCompatibilityUUIDs</key>
+	<array>
+		<string># For mail version 15.0 (3693.40.0.1.81) on OS X Version 12.1 (build 21C52)</string>
+		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
I grabbed some of these from a forum, the 12.1 came from my machine.

There's another list here,
https://ja.osdn.net/projects/letter-fix/scm/git/LetterFix/blobs/6e19f0106860781a3110009d01134bdb780be543/Info.plist

## Mine

```xml
<key>Supported11.10PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.1PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.2PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.3PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.4PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.5PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.6PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.7PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported11.8PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported12.0PluginCompatibilityUUIDs</key>
	<array>
		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
	</array>
	<key>Supported12.1PluginCompatibilityUUIDs</key>
	<array>
		<string># For mail version 15.0 (3693.40.0.1.81) on OS X Version 12.1 (build 21C52)</string>
		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
	</array>
```

## Alternative

```xml
    <key>Supported11.0PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
    </array>
    <key>Supported11.1PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
    </array>
    <key>Supported11.2PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
    </array>
    <key>Supported11.3PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
    </array>
    <key>Supported11.4PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
    </array>
    <key>Supported11.5PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
    </array>
    <key>Supported11.6PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
    </array>
    <key>Supported12.0PluginCompatibilityUUIDs</key>
    <array>
        <string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
        <string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
        <string>25288CEF-7D9B-49A8-BE6B-E41DA6277CF3</string>
    </array>
    <key>Supported12.1PluginCompatibilityUUIDs</key>
    <array>
        <string>25288CEF-7D9B-49A8-BE6B-E41DA6277CF3</string>
        <string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
    </array>
```