### PR TITLE
support newer pymobiledevice3

### DIFF
--- a/AltJIT/Commands/EnableJIT.swift
+++ b/AltJIT/Commands/EnableJIT.swift
@@ -89,7 +89,7 @@ private extension EnableJIT
         {
             Logger.main.info("Starting RSD tunnel with timeout: \(self.timeout)")
             
-            let process = try Process.launch(.python3, arguments: ["-u", "-m", "pymobiledevice3", "remote", "start-quic-tunnel", "--udid", self.udid], environment: self.processEnvironment)
+            let process = try Process.launch(.python3, arguments: ["-u", "-m", "pymobiledevice3", "remote", "start-tunnel", "--udid", self.udid], environment: self.processEnvironment)
             
             do
             {


### PR DESCRIPTION
Hi! I was struggling with enabling jit (#1345). Older versions of libraries, mentioned [here](https://faq.altstore.io/altstore-classic/altjit#troubleshooting), result in other bugs like this [one](https://github.com/altstoreio/altstore/issues/1345#issuecomment-1838242334)

Are there any downsides in updating to newer versions? Seems to work for me