### PR TITLE
fix: use default text color for news items if tintColor is undefined (closes #1696)

### DIFF
--- a/AltStore/News/NewsCollectionViewCell.swift
+++ b/AltStore/News/NewsCollectionViewCell.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import AltStoreCore
 
 class NewsCollectionViewCell: UICollectionViewCell
 {
@@ -33,5 +34,17 @@ class NewsCollectionViewCell: UICollectionViewCell
         self.imageView.clipsToBounds = true
         
         self.fediverseInteractionsView.layoutMargins = .zero
+    }
+    
+    func configure(with newsItem: NewsItem)
+    {
+        self.titleLabel.text = newsItem.title
+        self.captionLabel.text = newsItem.caption
+        self.contentBackgroundView.backgroundColor = newsItem.tintColor
+        
+        // Set text color to default iOS text color if tintColor is undefined
+        let textColor = newsItem.tintColor != nil ? UIColor.white : UIColor.label
+        self.titleLabel.textColor = textColor
+        self.captionLabel.textColor = textColor
     }
 }

--- a/AltStore/News/NewsViewController.swift
+++ b/AltStore/News/NewsViewController.swift
@@ -185,9 +185,7 @@ private extension NewsViewController
             cell.contentView.layoutMargins.left = self.view.layoutMargins.left
             cell.contentView.layoutMargins.right = self.view.layoutMargins.right
             
-            cell.titleLabel.text = newsItem.title
-            cell.captionLabel.text = newsItem.caption
-            cell.contentBackgroundView.backgroundColor = newsItem.tintColor
+            cell.configure(with: newsItem)
             
             cell.imageView.image = nil
             

--- a/AltStore/Sources/SourceDetailContentViewController.swift
+++ b/AltStore/Sources/SourceDetailContentViewController.swift
@@ -188,9 +188,7 @@ private extension SourceDetailContentViewController
             cell.layoutMargins = .zero
             cell.contentView.layoutMargins = .zero
             
-            cell.titleLabel.text = newsItem.title
-            cell.captionLabel.text = newsItem.caption
-            cell.contentBackgroundView.backgroundColor = newsItem.tintColor
+            cell.configure(with: newsItem)
             
             cell.imageView.image = nil
             cell.imageView.isHidden = true


### PR DESCRIPTION
Fixes the issue described in #1696, where leaving the tintColor of a news item undefined leads to unreadable text in light mode (white text on a white background). This PR addresses the issue by using a white color only when tintColor is set, and falling back to UIColor.label otherwise ([black in light mode, white in dark mode](https://gist.github.com/ncreated/35bf4d69d83d1a5ab408ff29a77fc9ff)).

To avoid code duplication, I refactored this new logic together with the existing setters into the configure() function of NewsCollectionViewCell, which now takes a full NewsItem as its parameter.

Tested on an iPhone 17 Pro Simulator with
- `media.partyknights.app/test-source.json` (source without tintColor)
- `partyknights.app/source` (source with tintColor)

I am happy to hear your feedback! 