### PR TITLE
Add Shortcuts action to install IPA files

### DIFF
--- a/AltStore/Intents/App Intents/AppShortcuts.swift
+++ b/AltStore/Intents/App Intents/AppShortcuts.swift
@@ -14,7 +14,7 @@ import AppIntents
 public struct ShortcutsProvider: AppShortcutsProvider
 {
     public static var appShortcuts: [AppShortcut] {
-        AppShortcut(intent: RefreshAllAppsIntent(), 
+        AppShortcut(intent: RefreshAllAppsIntent(),
                     phrases: [
                         "Refresh \(.applicationName)",
                         "Refresh \(.applicationName) apps",
@@ -23,6 +23,14 @@ public struct ShortcutsProvider: AppShortcutsProvider
                     ],
                     shortTitle: "Refresh All Apps",
                     systemImageName: "arrow.triangle.2.circlepath")
+
+        AppShortcut(intent: InstallIPAIntent(),
+                    phrases: [
+                        "Install IPA with \(.applicationName)",
+                        "Install an IPA with \(.applicationName)",
+                    ],
+                    shortTitle: "Install IPA",
+                    systemImageName: "square.and.arrow.down")
     }
     
     public static var shortcutTileColor: ShortcutTileColor {

--- a/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
+++ b/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
@@ -38,6 +38,78 @@ class IntentError: NSError, CustomLocalizedStringResourceConvertible
 }
 
 @available(iOS 17.0, *)
+struct InstallIPAIntent: AppIntent, ProgressReportingIntent
+{
+    static var title: LocalizedStringResource = "Install IPA"
+    static var description = IntentDescription("Installs an IPA file with AltStore.")
+    static var openAppWhenRun = false
+
+    @Parameter(title: "IPA File")
+    var ipaFile: IntentFile
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Install \(\.$ipaFile)")
+    }
+
+    init()
+    {
+        self.progress.completedUnitCount = 0
+        self.progress.totalUnitCount = 1
+    }
+
+    func perform() async throws -> some IntentResult
+    {
+        do
+        {
+            try await Self.startDatabaseIfNeeded()
+
+            let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
+            defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+            try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+
+            let ipaURL = temporaryDirectory.appendingPathComponent("App.ipa")
+            try self.ipaFile.data.write(to: ipaURL)
+
+            let intentProgress = self.progress
+            _ = try await AppManager.shared.installNonMarketplaceIPA(at: ipaURL) { progress in
+                intentProgress.addChild(progress, withPendingUnitCount: 1)
+            }
+
+            return .result()
+        }
+        catch
+        {
+            let intentError = IntentError(error)
+            throw intentError
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+fileprivate extension InstallIPAIntent
+{
+    static func startDatabaseIfNeeded() async throws
+    {
+        if !DatabaseManager.shared.isStarted
+        {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                DatabaseManager.shared.start { error in
+                    if let error
+                    {
+                        continuation.resume(throwing: error)
+                    }
+                    else
+                    {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 17.0, *)
 extension RefreshAllAppsIntent
 {
     private actor OperationActor
@@ -141,21 +213,7 @@ private extension RefreshAllAppsIntent
 {
     func refreshAllApps() async throws
     {
-        if !DatabaseManager.shared.isStarted
-        {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                DatabaseManager.shared.start { error in
-                    if let error
-                    {
-                        continuation.resume(throwing: error)
-                    }
-                    else
-                    {
-                        continuation.resume()
-                    }
-                }
-            }
-        }
+        try await InstallIPAIntent.startDatabaseIfNeeded()
         
         let context = DatabaseManager.shared.persistentContainer.newBackgroundContext()
         let installedApps = await context.perform { InstalledApp.fetchAppsForRefreshingAll(in: context) }

--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -247,7 +247,7 @@ extension AppManager
         return authenticationOperation
     }
     
-    func deactivateApps(for app: ALTApplication, presentingViewController: UIViewController, completion: @escaping (Result<Void, Error>) -> Void)
+    func deactivateApps(for app: ALTApplication, presentingViewController: UIViewController?, completion: @escaping (Result<Void, Error>) -> Void)
     {
         guard let activeAppsLimit = UserDefaults.standard.activeAppsLimit else { return completion(.success(())) }
         
@@ -283,7 +283,12 @@ extension AppManager
             let availableActiveApps = max(activeAppsLimit - activeAppsCount, 0)
             let requiredActiveSlots = UserDefaults.standard.activeAppLimitIncludesExtensions ? (1 + app.appExtensions.count) : 1
             guard requiredActiveSlots > availableActiveApps else { return completion(.success(())) }
-            
+
+            guard let presentingViewController else {
+                let failureReason = String(format: NSLocalizedString("AltStore needs to deactivate another app before installing %@.", comment: ""), app.name)
+                return completion(.failure(OperationError.forbidden(failureReason: failureReason)))
+            }
+
             let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: UIAlertAction.cancel.title, style: UIAlertAction.cancel.style) { (action) in
                 completion(.failure(OperationError.cancelled))
@@ -782,7 +787,29 @@ extension AppManager
         
         return group
     }
-    
+
+    func installNonMarketplaceIPA(at ipaURL: URL, context: AuthenticatedOperationContext = AuthenticatedOperationContext(), progressHandler: ((Progress) -> Void)? = nil) async throws -> InstalledApp
+    {
+        guard ipaURL.pathExtension.lowercased() == "ipa" else { throw OperationError.invalidApp }
+
+        let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let unzippedAppDirectory = temporaryDirectory.appendingPathComponent("App")
+        try FileManager.default.createDirectory(at: unzippedAppDirectory, withIntermediateDirectories: true)
+
+        let unzippedApplicationURL = try FileManager.default.unzipAppBundle(at: ipaURL, toDirectory: unzippedAppDirectory)
+        guard let application = ALTApplication(fileURL: unzippedApplicationURL) else { throw OperationError.invalidApp }
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<InstalledApp, Error>) in
+            let group = self.installNonMarketplaceApp(application, presentingViewController: nil, context: context) { result in
+                continuation.resume(with: result)
+            }
+
+            progressHandler?(group.progress)
+        }
+    }
+
     @discardableResult
     private func updateNonMarketplaceApp(_ installedApp: InstalledApp, to version: AppVersion? = nil, presentingViewController: UIViewController?, context: AuthenticatedOperationContext = AuthenticatedOperationContext(), completionHandler: @escaping (Result<InstalledApp, Error>) -> Void) -> RefreshGroup
     {
@@ -1436,9 +1463,9 @@ private extension AppManager
                     throw error
                 }
                                 
-                guard let app = context.app, let presentingViewController = context.authenticatedContext.presentingViewController else { throw OperationError.invalidParameters }
+                guard let app = context.app else { throw OperationError.invalidParameters }
                 
-                self?.deactivateApps(for: app, presentingViewController: presentingViewController) { result in
+                self?.deactivateApps(for: app, presentingViewController: context.authenticatedContext.presentingViewController) { result in
                     switch result
                     {
                     case .failure(let error): group.context.error = error


### PR DESCRIPTION
Adds an App Intent that lets Shortcuts install IPA files through AltStore.

Shortcuts automations can now provide an IPA file to AltStore, which will install it using the existing non-marketplace install flow without opening the AltStore UI. When the install process requires user interaction, the intent reports an error back to Shortcuts instead of showing a prompt.

Changes:

-Added an “Install IPA” App Shortcut.
-Added "InstallIPAIntent" with "IntentFile" input.
-Added "installNonMarketplaceIPA(at:)" for non-interactive installs.
-Updated app deactivation handling to fail when UI is required but no presenting view controller is available.
